### PR TITLE
feat: configure params support different type

### DIFF
--- a/cmd/agent_test.go
+++ b/cmd/agent_test.go
@@ -38,8 +38,8 @@ func TestExtract_MissingRequiredParams(t *testing.T) {
 func TestExtract_WithRequiredParams(t *testing.T) {
 	params, err := structpb.NewStruct(map[string]interface{}{
 		"a": "foo",
-		"b": "bar",
-		"c": "baz",
+		"b": 123,
+		"c": true,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -50,7 +50,7 @@ func TestExtract_WithRequiredParams(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := map[string]string{"a": "foo", "b": "bar", "c": "baz"}
+	expected := map[string]*structpb.Value{"a": structpb.NewStringValue("foo"), "b": structpb.NewNumberValue(123), "c": structpb.NewBoolValue(true)}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("actual: %v, want: %v", actual, expected)
 	}
@@ -60,18 +60,20 @@ func TestExtract_MissingOptionalParams(t *testing.T) {
 	params, err := structpb.NewStruct(map[string]interface{}{
 		"a": "foo",
 		"b": "bar",
+		"c": "",
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	actual, err := extract(params, "a", "b", "?c")
+	actual, err := extract(params, "a", "b", "?c", "?d")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// c is missing, but it's optional, so it's value is an empty string
-	expected := map[string]string{"a": "foo", "b": "bar", "c": ""}
+	// c is zero value, but it's optional, so it's value is an empty string
+	// d is not present, but it's optional, so it's value is nil
+	expected := map[string]*structpb.Value{"a": structpb.NewStringValue("foo"), "b": structpb.NewStringValue("bar"), "c": structpb.NewStringValue(""), "d": nil}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("actual: %v, want: %v", actual, expected)
 	}


### PR DESCRIPTION
In the previous implementation, `extract func` only extract string value. But client still can send different type in the params, we can not extract correct value.
Therefore, I modify `extract func` to return `map[string]*structpb.Value`.