### PR TITLE
fix: fix pg source restart loss tx problem

### DIFF
--- a/pkg/sql/source.go
+++ b/pkg/sql/source.go
@@ -24,3 +24,5 @@ var CreatePublication = `CREATE PUBLICATION %s FOR ALL TABLES;`
 var InstallExtension = `CREATE EXTENSION IF NOT EXISTS pgcapture;`
 
 var ServerVersionNum = `SHOW server_version_num;`
+
+var QueryReplicationSlot = `SELECT confirmed_flush_lsn FROM pg_replication_slots WHERE slot_name = $1;`


### PR DESCRIPTION
When pgSource restarts and cannot get the latest message id from Pulsar, possibly due to a timeout, starting replication with the XlogPos from IdentifySystem could lead to data loss. 

This is because the XlogPos represents the current database WAL flush location, not the confirmed flush LSN of the replication slot. Therefore, it could be greater than the begin and commit LSN. In this case, starting replication would not be able to replay the transactions between the confirmed flush LSN of the last replication slot and the XlogPos from IdentifySystem, resulting in data loss.

Therefore, if we cannot get the latest message from Pulsar, we should always start replaying from the confirmed flush LSN of the replication slot when restarting. Also, when the current LSN given to start replication is 0, PostgreSQL will default to using the confirmed flush LSN of the replication slot[^1].

[^1]: https://github.com/postgres/postgres/blob/8fa4a1ac61189efffb8b851ee77e1bc87360c445/src/backend/replication/logical/logical.c#L513