### PR TITLE
fix: fix go build fail

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -2,3 +2,4 @@ FROM golang:1.20-bullseye
 
 RUN apt-get update && apt-get install -y python3 python3-pip
 RUN python3 -m pip install grpcio-tools
+RUN git config --global --add safe.directory /src


### PR DESCRIPTION
forgot to add this `git config --global --add safe.directory /src` to solve go build error：
```
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
```