### PR TITLE
Fix corner cases in pgcapture.current_query()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.so
 __pycache__
 bin
+results/

--- a/hack/postgres/extension/Makefile
+++ b/hack/postgres/extension/Makefile
@@ -1,6 +1,8 @@
 # source: https://github.com/enova/pgl_ddl_deploy/blob/master/Makefile
 
 EXTENSION = pgcapture
+TESTS = $(wildcard sql/*)
+REGRESS = $(patsubst sql/%.sql,%,$(TESTS))
 DATA = pgcapture--0.1.sql
 MODULES = pgcapture
 

--- a/hack/postgres/extension/Makefile
+++ b/hack/postgres/extension/Makefile
@@ -4,7 +4,7 @@ EXTENSION = pgcapture
 DATA = pgcapture--0.1.sql
 MODULES = pgcapture
 
-PG_CONFIG = pg_config
+PG_CONFIG ?= pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 

--- a/hack/postgres/extension/expected/00_setup.out
+++ b/hack/postgres/extension/expected/00_setup.out
@@ -1,0 +1,1 @@
+CREATE EXTENSION pgcapture;

--- a/hack/postgres/extension/expected/01_basic.out
+++ b/hack/postgres/extension/expected/01_basic.out
@@ -1,8 +1,8 @@
 -- Test the DDL SRF
 SELECT * FROM pgcapture.current_query();
-              current_query               
-------------------------------------------
- SELECT * FROM pgcapture.current_query();
+ current_query 
+---------------
+ 
 (1 row)
 
 -- Test some basic DDL commands
@@ -15,13 +15,13 @@ CREATE INDEX ON nsp1.tbl (val) WHERE id % 2 = 0;
 CREATE SCHEMA nsp2\g
 -- Check the results
 SELECT query, unnest(tags) FROM pgcapture.ddl_logs ORDER BY id;
-                      query                       |     unnest      
---------------------------------------------------+-----------------
- CREATE TABLE ctas AS SELECT 1 as id;             | CREATE TABLE AS
- CREATE TABLE ct(id integer);                     | CREATE TABLE
- CREATE SCHEMA nsp1;                              | CREATE SCHEMA
- CREATE TABLE nsp1.tbl(id integer, val text);     | CREATE TABLE
- CREATE INDEX ON nsp1.tbl (val) WHERE id % 2 = 0; | CREATE INDEX
- CREATE SCHEMA nsp2                               | CREATE SCHEMA
+                      query                      |     unnest      
+-------------------------------------------------+-----------------
+ CREATE TABLE ctas AS SELECT 1 as id             | CREATE TABLE AS
+ CREATE TABLE ct(id integer)                     | CREATE TABLE
+ CREATE SCHEMA nsp1                              | CREATE SCHEMA
+ CREATE TABLE nsp1.tbl(id integer, val text)     | CREATE TABLE
+ CREATE INDEX ON nsp1.tbl (val) WHERE id % 2 = 0 | CREATE INDEX
+ CREATE SCHEMA nsp2                              | CREATE SCHEMA
 (6 rows)
 

--- a/hack/postgres/extension/expected/01_basic.out
+++ b/hack/postgres/extension/expected/01_basic.out
@@ -1,0 +1,27 @@
+-- Test the DDL SRF
+SELECT * FROM pgcapture.current_query();
+              current_query               
+------------------------------------------
+ SELECT * FROM pgcapture.current_query();
+(1 row)
+
+-- Test some basic DDL commands
+CREATE TABLE ctas AS SELECT 1 as id;
+CREATE TABLE ct(id integer);
+CREATE SCHEMA nsp1;
+CREATE TABLE nsp1.tbl(id integer, val text);
+CREATE INDEX ON nsp1.tbl (val) WHERE id % 2 = 0;
+-- DDL command that doesn't contain a trailing semi-column
+CREATE SCHEMA nsp2\g
+-- Check the results
+SELECT query, unnest(tags) FROM pgcapture.ddl_logs ORDER BY id;
+                      query                       |     unnest      
+--------------------------------------------------+-----------------
+ CREATE TABLE ctas AS SELECT 1 as id;             | CREATE TABLE AS
+ CREATE TABLE ct(id integer);                     | CREATE TABLE
+ CREATE SCHEMA nsp1;                              | CREATE SCHEMA
+ CREATE TABLE nsp1.tbl(id integer, val text);     | CREATE TABLE
+ CREATE INDEX ON nsp1.tbl (val) WHERE id % 2 = 0; | CREATE INDEX
+ CREATE SCHEMA nsp2                               | CREATE SCHEMA
+(6 rows)
+

--- a/hack/postgres/extension/expected/02_nested_ddl.out
+++ b/hack/postgres/extension/expected/02_nested_ddl.out
@@ -9,55 +9,10 @@ $$ LANGUAGE plpgsql;
 CREATE EXTENSION pg_stat_statements;
 -- Check the results
 SELECT query, unnest(tags) FROM pgcapture.ddl_logs ORDER BY id;
-                query                 |      unnest      
---------------------------------------+------------------
- DO $$                               +| DO
- BEGIN                               +| 
-     CREATE TABLE tbl1();            +| 
-     CREATE TABLE tbl2();            +| 
- END;                                +| 
- $$ LANGUAGE plpgsql;                 | 
- DO $$                               +| DO
- BEGIN                               +| 
-     CREATE TABLE tbl1();            +| 
-     CREATE TABLE tbl2();            +| 
- END;                                +| 
- $$ LANGUAGE plpgsql;                 | 
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
- CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
-(38 rows)
+                query                |      unnest      
+-------------------------------------+------------------
+ CREATE TABLE tbl1()                 | CREATE TABLE
+ CREATE TABLE tbl2()                 | CREATE TABLE
+ CREATE EXTENSION pg_stat_statements | CREATE EXTENSION
+(3 rows)
 

--- a/hack/postgres/extension/expected/02_nested_ddl.out
+++ b/hack/postgres/extension/expected/02_nested_ddl.out
@@ -1,0 +1,63 @@
+LOAD 'pgcapture';
+TRUNCATE pgcapture.ddl_logs;
+DO $$
+BEGIN
+    CREATE TABLE tbl1();
+    CREATE TABLE tbl2();
+END;
+$$ LANGUAGE plpgsql;
+CREATE EXTENSION pg_stat_statements;
+-- Check the results
+SELECT query, unnest(tags) FROM pgcapture.ddl_logs ORDER BY id;
+                query                 |      unnest      
+--------------------------------------+------------------
+ DO $$                               +| DO
+ BEGIN                               +| 
+     CREATE TABLE tbl1();            +| 
+     CREATE TABLE tbl2();            +| 
+ END;                                +| 
+ $$ LANGUAGE plpgsql;                 | 
+ DO $$                               +| DO
+ BEGIN                               +| 
+     CREATE TABLE tbl1();            +| 
+     CREATE TABLE tbl2();            +| 
+ END;                                +| 
+ $$ LANGUAGE plpgsql;                 | 
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+ CREATE EXTENSION pg_stat_statements; | CREATE EXTENSION
+(38 rows)
+

--- a/hack/postgres/extension/expected/03_multi_query.out
+++ b/hack/postgres/extension/expected/03_multi_query.out
@@ -1,0 +1,22 @@
+LOAD 'pgcapture';
+TRUNCATE pgcapture.ddl_logs;
+-- test multi-query statements mixing DDL / DML
+\o /dev/null
+-- older version of psql don't emit all the resultsets in multi-query
+SELECT 1\; CREATE TABLE multi(id integer)\; INSERT INTO multi SELECT 1;
+\o
+-- test multi-query statements mixing DDL
+DROP TABLE multi\; CREATE TABLE multi(val text);
+-- Check the results
+SELECT query, unnest(tags) FROM pgcapture.ddl_logs ORDER BY id;
+                                 query                                 |    unnest    
+-----------------------------------------------------------------------+--------------
+ SELECT 1; CREATE TABLE multi(id integer); INSERT INTO multi SELECT 1; | SELECT
+ SELECT 1; CREATE TABLE multi(id integer); INSERT INTO multi SELECT 1; | CREATE TABLE
+ SELECT 1; CREATE TABLE multi(id integer); INSERT INTO multi SELECT 1; | INSERT
+ DROP TABLE multi; CREATE TABLE multi(val text);                       | DROP TABLE
+ DROP TABLE multi; CREATE TABLE multi(val text);                       | CREATE TABLE
+ DROP TABLE multi; CREATE TABLE multi(val text);                       | DROP TABLE
+ DROP TABLE multi; CREATE TABLE multi(val text);                       | CREATE TABLE
+(7 rows)
+

--- a/hack/postgres/extension/expected/03_multi_query.out
+++ b/hack/postgres/extension/expected/03_multi_query.out
@@ -9,14 +9,10 @@ SELECT 1\; CREATE TABLE multi(id integer)\; INSERT INTO multi SELECT 1;
 DROP TABLE multi\; CREATE TABLE multi(val text);
 -- Check the results
 SELECT query, unnest(tags) FROM pgcapture.ddl_logs ORDER BY id;
-                                 query                                 |    unnest    
------------------------------------------------------------------------+--------------
- SELECT 1; CREATE TABLE multi(id integer); INSERT INTO multi SELECT 1; | SELECT
- SELECT 1; CREATE TABLE multi(id integer); INSERT INTO multi SELECT 1; | CREATE TABLE
- SELECT 1; CREATE TABLE multi(id integer); INSERT INTO multi SELECT 1; | INSERT
- DROP TABLE multi; CREATE TABLE multi(val text);                       | DROP TABLE
- DROP TABLE multi; CREATE TABLE multi(val text);                       | CREATE TABLE
- DROP TABLE multi; CREATE TABLE multi(val text);                       | DROP TABLE
- DROP TABLE multi; CREATE TABLE multi(val text);                       | CREATE TABLE
-(7 rows)
+             query              |    unnest    
+--------------------------------+--------------
+ CREATE TABLE multi(id integer) | CREATE TABLE
+ DROP TABLE multi               | DROP TABLE
+ CREATE TABLE multi(val text)   | CREATE TABLE
+(3 rows)
 

--- a/hack/postgres/extension/pgcapture.h
+++ b/hack/postgres/extension/pgcapture.h
@@ -1,0 +1,51 @@
+/*--------------------------------------------------------------------
+ * pgcapture.h
+ *
+ * Compatibility macros.
+ *--------------------------------------------------------------------
+ */
+#ifndef PGCAPTURE_H
+#define PGCAPTURE_H
+
+/* ProcessUtility_hook */
+#if PG_VERSION_NUM >= 140000
+#define UTILITY_HOOK_ARGS PlannedStmt *pstmt, const char *queryString, \
+							bool readOnlyTree, \
+							ProcessUtilityContext context, ParamListInfo params, \
+							QueryEnvironment *queryEnv, \
+							DestReceiver *dest, QueryCompletion *qc
+#define UTILITY_HOOK_ARG_NAMES pstmt, queryString, \
+							readOnlyTree, \
+							context, params, \
+							queryEnv, \
+							dest, qc
+#elif PG_VERSION_NUM >= 130000
+#define UTILITY_HOOK_ARGS PlannedStmt *pstmt, \
+							const char *queryString, \
+							ProcessUtilityContext context, \
+							ParamListInfo params, \
+							QueryEnvironment *queryEnv, \
+							DestReceiver *dest, QueryCompletion *qc
+#define UTILITY_HOOK_ARG_NAMES pstmt, \
+							queryString, \
+							context, \
+							params, \
+							queryEnv, \
+							dest, qc
+#elif PG_VERSION_NUM >= 100000
+#define UTILITY_HOOK_ARGS PlannedStmt *pstmt, \
+							const char *queryString, \
+							ProcessUtilityContext context, \
+							ParamListInfo params, \
+							QueryEnvironment *queryEnv, \
+							DestReceiver *dest, char *completionTag
+#define UTILITY_HOOK_ARG_NAMES pstmt, \
+							queryString, \
+							context, \
+							params, \
+							queryEnv, \
+							dest, completionTag
+#endif
+/* end of ProcessUtility_hook */
+
+#endif		/* PGCAPTURE_H */

--- a/hack/postgres/extension/sql/00_setup.sql
+++ b/hack/postgres/extension/sql/00_setup.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION pgcapture;

--- a/hack/postgres/extension/sql/01_basic.sql
+++ b/hack/postgres/extension/sql/01_basic.sql
@@ -1,0 +1,16 @@
+-- Test the DDL SRF
+SELECT * FROM pgcapture.current_query();
+
+-- Test some basic DDL commands
+CREATE TABLE ctas AS SELECT 1 as id;
+CREATE TABLE ct(id integer);
+
+CREATE SCHEMA nsp1;
+CREATE TABLE nsp1.tbl(id integer, val text);
+CREATE INDEX ON nsp1.tbl (val) WHERE id % 2 = 0;
+
+-- DDL command that doesn't contain a trailing semi-column
+CREATE SCHEMA nsp2\g
+
+-- Check the results
+SELECT query, unnest(tags) FROM pgcapture.ddl_logs ORDER BY id;

--- a/hack/postgres/extension/sql/02_nested_ddl.sql
+++ b/hack/postgres/extension/sql/02_nested_ddl.sql
@@ -1,0 +1,14 @@
+LOAD 'pgcapture';
+TRUNCATE pgcapture.ddl_logs;
+
+DO $$
+BEGIN
+    CREATE TABLE tbl1();
+    CREATE TABLE tbl2();
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE EXTENSION pg_stat_statements;
+
+-- Check the results
+SELECT query, unnest(tags) FROM pgcapture.ddl_logs ORDER BY id;

--- a/hack/postgres/extension/sql/03_multi_query.sql
+++ b/hack/postgres/extension/sql/03_multi_query.sql
@@ -1,0 +1,14 @@
+LOAD 'pgcapture';
+TRUNCATE pgcapture.ddl_logs;
+
+-- test multi-query statements mixing DDL / DML
+\o /dev/null
+-- older version of psql don't emit all the resultsets in multi-query
+SELECT 1\; CREATE TABLE multi(id integer)\; INSERT INTO multi SELECT 1;
+\o
+
+-- test multi-query statements mixing DDL
+DROP TABLE multi\; CREATE TABLE multi(val text);
+
+-- Check the results
+SELECT query, unnest(tags) FROM pgcapture.ddl_logs ORDER BY id;

--- a/hack/postgres/postgresql.conf
+++ b/hack/postgres/postgresql.conf
@@ -650,3 +650,4 @@ max_worker_processes = 10   # one per database needed on provider node
 max_replication_slots = 10  # one per node needed on provider node
 max_wal_senders = 10        # one per node needed on provider node
 shared_preload_libraries = 'pglogical'
+session_preload_libraries = 'pgcapture'


### PR DESCRIPTION
That function wasn't correctly handling multi-statement queries or CREATE EXTENSION commands that internally perform DDL.

I added first some minimal regression tests to show the current behavior with those corner cases and added the fix in the next commit.  Note that I didn't test those changes with pglogical.  I don't know much about this tool and I don't know if it can impact this approach.  If it does you can however ensure that pgcapture is executed first by changing the order of the modules in the needed *_preload_libraries parameter.

I also modifed the makefile to allow overloading the pg_config tool.  At least the RPM packagers rely on that so it would make their job easier if they want to package this tool.

I manually tested the changes on pg 12 to pg 16.  I didn't add a github workflow to run the tests on all supported versions as there shouldn't be much activity in that repository, but I can do it if you want.