### PR TITLE
feat: Ignore DDL query strings on temporary relations

### DIFF
--- a/hack/postgres/extension/Makefile
+++ b/hack/postgres/extension/Makefile
@@ -4,7 +4,10 @@ EXTENSION = pgcapture
 TESTS = $(wildcard sql/*)
 REGRESS = $(patsubst sql/%.sql,%,$(TESTS))
 DATA = pgcapture--0.1.sql
-MODULES = pgcapture
+MODULE_big = pgcapture
+
+OBJS = pgcapture.o \
+       pg_import.o
 
 PG_CONFIG ?= pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/hack/postgres/extension/expected/04_temp.out
+++ b/hack/postgres/extension/expected/04_temp.out
@@ -1,0 +1,46 @@
+LOAD 'pgcapture';
+-- Create a normal table that will later be dropped
+CREATE TABLE dropme();
+CREATE TABLE dropmetoo();
+TRUNCATE pgcapture.ddl_logs;
+-- Plain TEMP table should be ignored
+CREATE TEMPORARY TABLE tmp1();
+ALTER TABLE tmp1 ADD COLUMN id integer;
+-- Table created in the pg_temp schema should be ignored
+CREATE TABLE pg_temp.tmp2();
+ALTER TABLE pg_temp.tmp2 ADD COLUMN id integer;
+-- Table created in the pg_temp schema using the search_path should alse be
+-- ignored
+SET search_path TO not_a_schema, pg_temp, public;
+CREATE TABLE tmp3();
+ALTER TABLE tmp3 ADD COLUMN id integer;
+RESET search_path;
+-- CTAS / SELECT INTO for temp tables should be ignored
+CREATE TABLE pg_temp.tmp4 AS SELECT 1 AS id;
+-- CREATE TEMP VIEW should be ignored
+CREATE TEMP VIEW v1 AS SELECT 1 AS id;
+-- Implicitly temp view creation should be ignored
+CREATE VIEW v2 AS SELECT * FROM tmp3;
+NOTICE:  view "v2" will be a temporary view
+-- ALTER ... RENAME should ignore temp relations
+ALTER TABLE tmp4 RENAME COLUMN id TO id2;
+ALTER TABLE tmp4 RENAME TO tmp4b;
+-- Check the results
+SELECT query, unnest(tags) FROM pgcapture.ddl_logs ORDER BY id;
+ query | unnest 
+-------+--------
+(0 rows)
+
+-- Dropping only temp tables should be ignored
+DROP TABLE tmp1, tmp2;
+-- But dropping a mix of temp and regular table should preserve the regular
+-- table names
+DROP TABLE tmp3, pg_temp.tmp3, dropme, tmp4b, dropmetoo CASCADE;
+NOTICE:  drop cascades to view v2
+-- Check the results
+SELECT query, unnest(tags) FROM pgcapture.ddl_logs ORDER BY id;
+                query                 |   unnest   
+--------------------------------------+------------
+ DROP TABLE dropme, dropmetoo CASCADE | DROP TABLE
+(1 row)
+

--- a/hack/postgres/extension/pg_import.c
+++ b/hack/postgres/extension/pg_import.c
@@ -1,0 +1,428 @@
+/*--------------------------------------------------------------------
+ * pg_import.c
+ *
+ * Code imported from upstream.
+ *--------------------------------------------------------------------
+ */
+
+#include "postgres.h"
+
+#if PG_VERSION_NUM < 120000
+#include "access/htup_details.h"
+#endif
+#if PG_VERSION_NUM >= 160000
+#include "catalog/pg_namespace.h"
+#endif
+#include "utils/lsyscache.h"
+
+/*--- Local includes ---*/
+
+#include "pg_import.h"
+
+/*--- Structs --- */
+
+/* Imported from src/backend/commands/tablecmds.c */
+struct dropmsgstrings
+{
+	char		kind;
+	int			nonexistent_code;
+	const char *nonexistent_msg;
+	const char *skipping_msg;
+	const char *nota_msg;
+	const char *drophint_msg;
+};
+
+/* Imported from src/backend/commands/tablecmds.c */
+static const struct dropmsgstrings dropmsgstringarray[] = {
+	{RELKIND_RELATION,
+		ERRCODE_UNDEFINED_TABLE,
+		gettext_noop("table \"%s\" does not exist"),
+		gettext_noop("table \"%s\" does not exist, skipping"),
+		gettext_noop("\"%s\" is not a table"),
+	gettext_noop("Use DROP TABLE to remove a table.")},
+	{RELKIND_SEQUENCE,
+		ERRCODE_UNDEFINED_TABLE,
+		gettext_noop("sequence \"%s\" does not exist"),
+		gettext_noop("sequence \"%s\" does not exist, skipping"),
+		gettext_noop("\"%s\" is not a sequence"),
+	gettext_noop("Use DROP SEQUENCE to remove a sequence.")},
+	{RELKIND_VIEW,
+		ERRCODE_UNDEFINED_TABLE,
+		gettext_noop("view \"%s\" does not exist"),
+		gettext_noop("view \"%s\" does not exist, skipping"),
+		gettext_noop("\"%s\" is not a view"),
+	gettext_noop("Use DROP VIEW to remove a view.")},
+	{RELKIND_MATVIEW,
+		ERRCODE_UNDEFINED_TABLE,
+		gettext_noop("materialized view \"%s\" does not exist"),
+		gettext_noop("materialized view \"%s\" does not exist, skipping"),
+		gettext_noop("\"%s\" is not a materialized view"),
+	gettext_noop("Use DROP MATERIALIZED VIEW to remove a materialized view.")},
+	{RELKIND_INDEX,
+		ERRCODE_UNDEFINED_OBJECT,
+		gettext_noop("index \"%s\" does not exist"),
+		gettext_noop("index \"%s\" does not exist, skipping"),
+		gettext_noop("\"%s\" is not an index"),
+	gettext_noop("Use DROP INDEX to remove an index.")},
+	{RELKIND_COMPOSITE_TYPE,
+		ERRCODE_UNDEFINED_OBJECT,
+		gettext_noop("type \"%s\" does not exist"),
+		gettext_noop("type \"%s\" does not exist, skipping"),
+		gettext_noop("\"%s\" is not a type"),
+	gettext_noop("Use DROP TYPE to remove a type.")},
+	{RELKIND_FOREIGN_TABLE,
+		ERRCODE_UNDEFINED_OBJECT,
+		gettext_noop("foreign table \"%s\" does not exist"),
+		gettext_noop("foreign table \"%s\" does not exist, skipping"),
+		gettext_noop("\"%s\" is not a foreign table"),
+	gettext_noop("Use DROP FOREIGN TABLE to remove a foreign table.")},
+	{RELKIND_PARTITIONED_TABLE,
+		ERRCODE_UNDEFINED_TABLE,
+		gettext_noop("table \"%s\" does not exist"),
+		gettext_noop("table \"%s\" does not exist, skipping"),
+		gettext_noop("\"%s\" is not a table"),
+	gettext_noop("Use DROP TABLE to remove a table.")},
+	{RELKIND_PARTITIONED_INDEX,
+		ERRCODE_UNDEFINED_OBJECT,
+		gettext_noop("index \"%s\" does not exist"),
+		gettext_noop("index \"%s\" does not exist, skipping"),
+		gettext_noop("\"%s\" is not an index"),
+	gettext_noop("Use DROP INDEX to remove an index.")},
+	{'\0', 0, NULL, NULL, NULL, NULL}
+};
+
+/*--- Functions --- */
+
+static void DropErrorMsgWrongType(const char *relname, char wrongkind,
+								  char rightkind);
+
+/*--- Implementation --- */
+
+/* Imported from src/backend/commands/tablecmds.c */
+static void
+DropErrorMsgWrongType(const char *relname, char wrongkind, char rightkind)
+{
+	const struct dropmsgstrings *rentry;
+	const struct dropmsgstrings *wentry;
+
+	for (rentry = dropmsgstringarray; rentry->kind != '\0'; rentry++)
+		if (rentry->kind == rightkind)
+			break;
+	Assert(rentry->kind != '\0');
+
+	for (wentry = dropmsgstringarray; wentry->kind != '\0'; wentry++)
+		if (wentry->kind == wrongkind)
+			break;
+	/* wrongkind could be something we don't have in our table... */
+
+	ereport(ERROR,
+			(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+			 errmsg(rentry->nota_msg, relname),
+			 (wentry->kind != '\0') ? errhint("%s", _(wentry->drophint_msg)) : 0));
+}
+
+/* Imported from src/backend/commands/tablecmds.c */
+void
+RangeVarCallbackForAlterRelation(const RangeVar *rv, Oid relid, Oid oldrelid,
+								 void *arg)
+{
+	Node	   *stmt = (Node *) arg;
+	ObjectType	reltype;
+	HeapTuple	tuple;
+	Form_pg_class classform;
+	AclResult	aclresult;
+	char		relkind;
+
+	tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(relid));
+	if (!HeapTupleIsValid(tuple))
+		return;					/* concurrently dropped */
+	classform = (Form_pg_class) GETSTRUCT(tuple);
+	relkind = classform->relkind;
+
+	/* Must own relation. */
+#if PG_VERSION_NUM < 160000
+	if (!pg_class_ownercheck(relid, GetUserId()))
+		aclcheck_error(ACLCHECK_NOT_OWNER, get_relkind_objtype(get_rel_relkind(relid)), rv->relname);
+#else
+	if (!object_ownercheck(RelationRelationId, relid, GetUserId()))
+		aclcheck_error(ACLCHECK_NOT_OWNER, get_relkind_objtype(get_rel_relkind(relid)), rv->relname);
+#endif
+
+	/* No system table modifications unless explicitly allowed. */
+	if (!allowSystemTableMods && IsSystemClass(relid, classform))
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("permission denied: \"%s\" is a system catalog",
+						rv->relname)));
+
+	/*
+	 * Extract the specified relation type from the statement parse tree.
+	 *
+	 * Also, for ALTER .. RENAME, check permissions: the user must (still)
+	 * have CREATE rights on the containing namespace.
+	 */
+	if (IsA(stmt, RenameStmt))
+	{
+#if PG_VERSION_NUM < 160000
+		aclresult = pg_namespace_aclcheck(classform->relnamespace,
+										  GetUserId(), ACL_CREATE);
+#else
+		aclresult = object_aclcheck(NamespaceRelationId, classform->relnamespace,
+									GetUserId(), ACL_CREATE);
+#endif
+		if (aclresult != ACLCHECK_OK)
+			aclcheck_error(aclresult, OBJECT_SCHEMA,
+						   get_namespace_name(classform->relnamespace));
+		reltype = ((RenameStmt *) stmt)->renameType;
+	}
+	else if (IsA(stmt, AlterObjectSchemaStmt))
+		reltype = ((AlterObjectSchemaStmt *) stmt)->objectType;
+
+	else if (IsA(stmt, AlterTableStmt))
+#if PG_VERSION_NUM < 140000
+		reltype = ((AlterTableStmt *) stmt)->relkind;
+#else
+		reltype = ((AlterTableStmt *) stmt)->objtype;
+#endif
+	else
+	{
+		elog(ERROR, "unrecognized node type: %d", (int) nodeTag(stmt));
+		reltype = OBJECT_TABLE; /* placate compiler */
+	}
+
+	/*
+	 * For compatibility with prior releases, we allow ALTER TABLE to be used
+	 * with most other types of relations (but not composite types). We allow
+	 * similar flexibility for ALTER INDEX in the case of RENAME, but not
+	 * otherwise.  Otherwise, the user must select the correct form of the
+	 * command for the relation at issue.
+	 */
+	if (reltype == OBJECT_SEQUENCE && relkind != RELKIND_SEQUENCE)
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("\"%s\" is not a sequence", rv->relname)));
+
+	if (reltype == OBJECT_VIEW && relkind != RELKIND_VIEW)
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("\"%s\" is not a view", rv->relname)));
+
+	if (reltype == OBJECT_MATVIEW && relkind != RELKIND_MATVIEW)
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("\"%s\" is not a materialized view", rv->relname)));
+
+	if (reltype == OBJECT_FOREIGN_TABLE && relkind != RELKIND_FOREIGN_TABLE)
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("\"%s\" is not a foreign table", rv->relname)));
+
+	if (reltype == OBJECT_TYPE && relkind != RELKIND_COMPOSITE_TYPE)
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("\"%s\" is not a composite type", rv->relname)));
+
+	if (reltype == OBJECT_INDEX && relkind != RELKIND_INDEX &&
+		relkind != RELKIND_PARTITIONED_INDEX
+		&& !IsA(stmt, RenameStmt))
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("\"%s\" is not an index", rv->relname)));
+
+	/*
+	 * Don't allow ALTER TABLE on composite types. We want people to use ALTER
+	 * TYPE for that.
+	 */
+	if (reltype != OBJECT_TYPE && relkind == RELKIND_COMPOSITE_TYPE)
+		ereport(ERROR,
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+				 errmsg("\"%s\" is a composite type", rv->relname),
+		/* translator: %s is an SQL ALTER command */
+				 errhint("Use %s instead.",
+						 "ALTER TYPE")));
+
+	/*
+	 * Don't allow ALTER TABLE .. SET SCHEMA on relations that can't be moved
+	 * to a different schema, such as indexes and TOAST tables.
+	 */
+	if (IsA(stmt, AlterObjectSchemaStmt))
+	{
+		if (relkind == RELKIND_INDEX || relkind == RELKIND_PARTITIONED_INDEX)
+			ereport(ERROR,
+					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+					 errmsg("cannot change schema of index \"%s\"",
+							rv->relname),
+					 errhint("Change the schema of the table instead.")));
+		else if (relkind == RELKIND_COMPOSITE_TYPE)
+			ereport(ERROR,
+					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+					 errmsg("cannot change schema of composite type \"%s\"",
+							rv->relname),
+			/* translator: %s is an SQL ALTER command */
+					 errhint("Use %s instead.",
+							 "ALTER TYPE")));
+		else if (relkind == RELKIND_TOASTVALUE)
+			ereport(ERROR,
+					(errcode(ERRCODE_WRONG_OBJECT_TYPE),
+					 errmsg("cannot change schema of TOAST table \"%s\"",
+							rv->relname),
+					 errhint("Change the schema of the table instead.")));
+	}
+
+	ReleaseSysCache(tuple);
+}
+
+
+/* Imported from src/backend/commands/tablecmds.c */
+void
+RangeVarCallbackForDropRelation(const RangeVar *rel, Oid relOid, Oid oldRelOid,
+								void *arg)
+{
+	HeapTuple	tuple;
+	struct DropRelationCallbackState *state;
+	char		expected_relkind;
+	bool		is_partition;
+	Form_pg_class classform;
+	LOCKMODE	heap_lockmode;
+	bool		invalid_system_index = false;
+
+	state = (struct DropRelationCallbackState *) arg;
+	heap_lockmode = state->heap_lockmode;
+
+	/*
+	 * If we previously locked some other index's heap, and the name we're
+	 * looking up no longer refers to that relation, release the now-useless
+	 * lock.
+	 */
+	if (relOid != oldRelOid && OidIsValid(state->heapOid))
+	{
+		UnlockRelationOid(state->heapOid, heap_lockmode);
+		state->heapOid = InvalidOid;
+	}
+
+	/*
+	 * Similarly, if we previously locked some other partition's heap, and the
+	 * name we're looking up no longer refers to that relation, release the
+	 * now-useless lock.
+	 */
+	if (relOid != oldRelOid && OidIsValid(state->partParentOid))
+	{
+		UnlockRelationOid(state->partParentOid, AccessExclusiveLock);
+		state->partParentOid = InvalidOid;
+	}
+
+	/* Didn't find a relation, so no need for locking or permission checks. */
+	if (!OidIsValid(relOid))
+		return;
+
+	tuple = SearchSysCache1(RELOID, ObjectIdGetDatum(relOid));
+	if (!HeapTupleIsValid(tuple))
+		return;					/* concurrently dropped, so nothing to do */
+	classform = (Form_pg_class) GETSTRUCT(tuple);
+	is_partition = classform->relispartition;
+
+	/* Pass back some data to save lookups in RemoveRelations */
+	state->actual_relkind = classform->relkind;
+	state->actual_relpersistence = classform->relpersistence;
+
+	/*
+	 * Both RELKIND_RELATION and RELKIND_PARTITIONED_TABLE are OBJECT_TABLE,
+	 * but RemoveRelations() can only pass one relkind for a given relation.
+	 * It chooses RELKIND_RELATION for both regular and partitioned tables.
+	 * That means we must be careful before giving the wrong type error when
+	 * the relation is RELKIND_PARTITIONED_TABLE.  An equivalent problem
+	 * exists with indexes.
+	 */
+	if (classform->relkind == RELKIND_PARTITIONED_TABLE)
+		expected_relkind = RELKIND_RELATION;
+	else if (classform->relkind == RELKIND_PARTITIONED_INDEX)
+		expected_relkind = RELKIND_INDEX;
+	else
+		expected_relkind = classform->relkind;
+
+	if (state->expected_relkind != expected_relkind)
+		DropErrorMsgWrongType(rel->relname, classform->relkind,
+							  state->expected_relkind);
+
+	/* Allow DROP to either table owner or schema owner */
+#if PG_VERSION_NUM < 160000
+	if (!pg_class_ownercheck(relOid, GetUserId()) &&
+		!pg_namespace_ownercheck(classform->relnamespace, GetUserId()))
+#else
+	if (!object_ownercheck(RelationRelationId, relOid, GetUserId()) &&
+		!object_ownercheck(NamespaceRelationId, classform->relnamespace, GetUserId()))
+#endif
+		aclcheck_error(ACLCHECK_NOT_OWNER,
+					   get_relkind_objtype(classform->relkind),
+					   rel->relname);
+
+	/*
+	 * Check the case of a system index that might have been invalidated by a
+	 * failed concurrent process and allow its drop. For the time being, this
+	 * only concerns indexes of toast relations that became invalid during a
+	 * REINDEX CONCURRENTLY process.
+	 */
+	if (IsSystemClass(relOid, classform) && classform->relkind == RELKIND_INDEX)
+	{
+		HeapTuple	locTuple;
+		Form_pg_index indexform;
+		bool		indisvalid;
+
+		locTuple = SearchSysCache1(INDEXRELID, ObjectIdGetDatum(relOid));
+		if (!HeapTupleIsValid(locTuple))
+		{
+			ReleaseSysCache(tuple);
+			return;
+		}
+
+		indexform = (Form_pg_index) GETSTRUCT(locTuple);
+		indisvalid = indexform->indisvalid;
+		ReleaseSysCache(locTuple);
+
+		/* Mark object as being an invalid index of system catalogs */
+		if (!indisvalid)
+			invalid_system_index = true;
+	}
+
+	/* In the case of an invalid index, it is fine to bypass this check */
+	if (!invalid_system_index && !allowSystemTableMods && IsSystemClass(relOid, classform))
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("permission denied: \"%s\" is a system catalog",
+						rel->relname)));
+
+	ReleaseSysCache(tuple);
+
+	/*
+	 * In DROP INDEX, attempt to acquire lock on the parent table before
+	 * locking the index.  index_drop() will need this anyway, and since
+	 * regular queries lock tables before their indexes, we risk deadlock if
+	 * we do it the other way around.  No error if we don't find a pg_index
+	 * entry, though --- the relation may have been dropped.  Note that this
+	 * code will execute for either plain or partitioned indexes.
+	 */
+	if (expected_relkind == RELKIND_INDEX &&
+		relOid != oldRelOid)
+	{
+		state->heapOid = IndexGetRelation(relOid, true);
+		if (OidIsValid(state->heapOid))
+			LockRelationOid(state->heapOid, heap_lockmode);
+	}
+
+	/*
+	 * Similarly, if the relation is a partition, we must acquire lock on its
+	 * parent before locking the partition.  That's because queries lock the
+	 * parent before its partitions, so we risk deadlock if we do it the other
+	 * way around.
+	 */
+	if (is_partition && relOid != oldRelOid)
+	{
+#if PG_VERSION_NUM < 140000
+		state->partParentOid = get_partition_parent(relOid);
+#else
+		state->partParentOid = get_partition_parent(relOid, true);
+#endif
+		if (OidIsValid(state->partParentOid))
+			LockRelationOid(state->partParentOid, AccessExclusiveLock);
+	}
+}

--- a/hack/postgres/extension/pg_import.h
+++ b/hack/postgres/extension/pg_import.h
@@ -1,0 +1,42 @@
+/*--------------------------------------------------------------------
+ * pg_import.h
+ *
+ * Code imported from upstream.
+ *--------------------------------------------------------------------
+ */
+#ifndef PG_IMPORT_H
+#define PG_IMPORT_H
+
+#include "postgres.h"
+
+#include "catalog/catalog.h"
+#include "catalog/index.h"
+#include "catalog/partition.h"
+#include "miscadmin.h"
+#include "storage/lmgr.h"
+#include "utils/acl.h"
+#include "utils/syscache.h"
+
+/* Imported from src/backend/commands/tablecmds.c */
+struct DropRelationCallbackState
+{
+	/* These fields are set by RemoveRelations: */
+	char		expected_relkind;
+	LOCKMODE	heap_lockmode;
+	/* These fields are state to track which subsidiary locks are held: */
+	Oid			heapOid;
+	Oid			partParentOid;
+	/* These fields are passed back by RangeVarCallbackForDropRelation: */
+	char		actual_relkind;
+	char		actual_relpersistence;
+};
+
+/* Imported from src/backend/commands/tablecmds.c */
+void RangeVarCallbackForAlterRelation(const RangeVar *rv, Oid relid,
+											 Oid oldrelid, void *arg);
+
+/* Imported from src/backend/commands/tablecmds.c */
+void RangeVarCallbackForDropRelation(const RangeVar *rel, Oid relOid,
+											Oid oldRelOid, void *arg);
+
+#endif		/* PG_IMPORT_H */

--- a/hack/postgres/extension/pgcapture.c
+++ b/hack/postgres/extension/pgcapture.c
@@ -1,23 +1,36 @@
 #include "postgres.h"
 
+#include "catalog/namespace.h"
+#include "catalog/pg_authid.h"
+#include "catalog/pg_class.h"
+#include "catalog/pg_namespace.h"
 #include "catalog/pg_type.h"
 #include "commands/extension.h"
+#include "commands/tablecmds.h"
 #include "fmgr.h"
+#include "parser/analyze.h"
+#include "parser/parse_relation.h"
 #include "parser/parser.h"
 #include "parser/scansup.h"
+#include "storage/lmgr.h"
 #include "tcop/utility.h"
 #include "utils/builtins.h"
+#include "utils/inval.h"
+#include "utils/lsyscache.h"
+#include "utils/varlena.h"
 
 /*--- Local includes ---*/
 
 #include "pgcapture.h"
+#include "pg_import.h"
+
 
 PG_MODULE_MAGIC;
 
 /*--- Private variables ---*/
 
 /* Cache of the current utility command query string. */
-char *pgc_current_utility_string = NULL;
+static char *pgc_current_utility_string = NULL;
 
 /*--- Functions --- */
 
@@ -26,7 +39,10 @@ PGDLLEXPORT void _PG_init(void);
 static void pgc_ProcessUtility_hook(UTILITY_HOOK_ARGS);
 static ProcessUtility_hook_type prev_ProcessUtility = NULL;
 
-char *extract_query_text(const char *query, int query_location, int query_len);
+char *extract_query_text(PlannedStmt *pstmt, const char *query,
+						 int query_location, int query_len);
+Oid rv_get_rename_relid(RenameStmt *rename);
+Oid rv_get_drop_relid(RangeVar *rv, char relkind, bool concurrent);
 
 PG_FUNCTION_INFO_V1(pgl_ddl_deploy_current_query);
 PG_FUNCTION_INFO_V1(sql_command_tags);
@@ -58,7 +74,8 @@ pgc_ProcessUtility_hook(UTILITY_HOOK_ARGS)
 	if (creating_extension)
 		pgc_current_utility_string = NULL;
 	else
-		pgc_current_utility_string = extract_query_text(queryString,
+		pgc_current_utility_string = extract_query_text(pstmt,
+														queryString,
 														pstmt->stmt_location,
 														pstmt->stmt_len);
 
@@ -73,14 +90,280 @@ pgc_ProcessUtility_hook(UTILITY_HOOK_ARGS)
 
 /*
  * Given a possibly multi-statement source string, return a palloc'd copy of
- * the relevant part of the string.
+ * the relevant part of the string, ignoring temporary relations.
  *
-* Adapted from upstream pg_stat_statements / CleanQuerytext.
+ * For any relation related that is not a DROP TABLE, if the target relation is
+ * temporary the statement is entirely ignored and NULL is returned.
+ *
+ * For a DROP TABLE statement, all temporary relation names are removed for the
+ * statement if any.  If the resulting command doesn't have any table then NULL
+ * is also returned.
  */
 char *
-extract_query_text(const char *query, int query_location, int query_len)
+extract_query_text(PlannedStmt *pstmt, const char *query, int query_location,
+				   int query_len)
 {
-	char *extracted;
+	char	   *extracted;
+	Node	   *stmt = pstmt->utilityStmt;
+
+	Assert(stmt);
+
+	switch (nodeTag(stmt))
+	{
+		case T_CreateStmt:
+			{
+				CreateStmt *create = castNode(CreateStmt, stmt);
+				Oid			nspid;
+
+				/*
+				 * Get the target schema the given CREATE TABLE will use.
+				 * This uses the same approach as DefineRelation to ensure a
+				 * consistent schema detection.
+				 */
+				nspid = RangeVarGetAndCheckCreationNamespace(create->relation,
+															 NoLock, NULL);
+
+				/* Ignore the statement if it's the temp schema. */
+				if (isTempNamespace(nspid))
+					return NULL;
+
+				break;
+			}
+		case T_AlterTableStmt:
+			{
+				AlterTableStmt *atstmt = castNode(AlterTableStmt, stmt);
+				Oid			relid;
+				LOCKMODE	lockmode;
+
+				/*
+				 * Get the underlying relation.
+				 * This uses the same approach as ProcessUtilitySlow for an
+				 * ALTER TABLE statement to ensure consistent relation
+				 * detection.
+				 */
+				lockmode = AlterTableGetLockLevel(atstmt->cmds);
+				relid = AlterTableLookupRelation(atstmt, lockmode);
+
+				/* Ignore the statement if it's the temp schema. */
+				if (get_rel_persistence(relid) == RELPERSISTENCE_TEMP)
+					return NULL;
+
+				break;
+			}
+		case T_CreateTableAsStmt:
+			{
+				CreateTableAsStmt *create = castNode(CreateTableAsStmt, stmt);
+				Oid			nspid;
+
+				/*
+				 * Get the target schema the given CREATE TABLE AS / SELECT
+				 * INTO will use.
+				 * This uses the same approach as ExecCreateTableAs to ensure a
+				 * consistent schema detection.
+				 */
+				nspid = RangeVarGetAndCheckCreationNamespace(create->into->rel,
+															 NoLock, NULL);
+
+				/* Ignore the statement if it's the temp schema. */
+				if (isTempNamespace(nspid))
+					return NULL;
+
+				break;
+			}
+		case T_DropStmt:
+			{
+				DropStmt   *drop = castNode(DropStmt, stmt);
+				char	   *dropkind;
+				char		relkind;
+				StringInfo  buf;
+				ListCell   *lc;
+				bool		do_check = true;
+
+				switch (drop->removeType)
+				{
+					case OBJECT_INDEX:
+						dropkind = "INDEX";
+						relkind = RELKIND_INDEX;
+						break;
+					case OBJECT_TABLE:
+						dropkind = "TABLE";
+						relkind = RELKIND_RELATION;
+						break;
+					case OBJECT_SEQUENCE:
+						dropkind = "SEQUENCE";
+						relkind = RELKIND_SEQUENCE;
+						break;
+					case OBJECT_VIEW:
+						dropkind = "VIEW";
+						relkind = RELKIND_VIEW;
+						break;
+					default:
+						/* We won't need to check for temp relation. */
+						do_check = false;
+						break;
+				}
+
+				/*
+				 * If the DROP statement cannot contain temp relations, stop
+				 * here and let the later code extract the query text.
+				 */
+				if (!do_check)
+					break;
+
+				/*
+				 * The DROP might contain temp relation.  Loop over all objects
+				 * in the statement and generate a new DROP statement, ignoring
+				 * all references to temporary relations.
+				 */
+				buf = makeStringInfo();
+
+				foreach(lc, drop->objects)
+				{
+					List	   *names = lfirst(lc);
+					RangeVar   *rv = makeRangeVarFromNameList(names);
+					Oid			relid;
+					char	   *nspname;
+					char	   *relname;
+
+					relid = rv_get_drop_relid(rv, relkind, drop->concurrent);
+
+					if (get_rel_persistence(relid) == RELPERSISTENCE_TEMP)
+						continue;
+
+					nspname = get_namespace_name(get_rel_namespace(relid));
+					relname = get_rel_name(relid);
+
+					if (buf->len == 0)
+					{
+						/*
+						 * First relation found.  Start generating the DROP
+						 * command.
+						 * We generate it using the same flags, so we need to
+						 * detect whether the original query specified
+						 * CONCURRENTLY and / or IF EXISTS.
+						 */
+						appendStringInfo(buf, "DROP %s ", dropkind);
+
+						if (drop->concurrent)
+							appendStringInfo(buf, "CONCURRENTLY ");
+
+						if (drop->missing_ok)
+							appendStringInfo(buf, "IF EXISTS ");
+					}
+					else
+					{
+						/*
+						 * Another relation found, separate the name with a
+						 * coma.
+						 */
+						appendStringInfoString(buf, ", ");
+					}
+
+					if (rv->schemaname)
+						appendStringInfo(buf, "%s.%s",
+										 quote_identifier(nspname),
+										 quote_identifier(relname));
+					else
+						appendStringInfo(buf, "%s", quote_identifier(relname));
+				}
+
+				/*
+				 * If we generated a query, return it.  Otherwise, return NULL
+				 * as it mean it was a DROP that contained only temporary
+				 * relations that should be ignored.
+				 */
+				if (buf->len > 0)
+				{
+					/* We need to finalize the query string before sending, if
+					 * CASCADE was specified.
+					 */
+					if (drop->behavior == DROP_CASCADE)
+						appendStringInfo(buf, " CASCADE");
+
+					return buf->data;
+				}
+				else
+					return NULL;
+
+				break;
+			}
+		case T_RenameStmt:
+			{
+				RenameStmt *rename = castNode(RenameStmt, stmt);
+				Oid			relid;
+				bool		do_check;
+
+				switch (rename->renameType)
+				{
+					case OBJECT_ATTRIBUTE:
+					case OBJECT_COLUMN:
+					case OBJECT_INDEX:
+					case OBJECT_TABLE:
+					case OBJECT_SEQUENCE:
+					case OBJECT_VIEW:
+						/* We will need to check for temp relation. */
+						do_check = true;
+						break;
+					default:
+						/* We won't need to check for temp relation. */
+						do_check = false;
+						break;
+				}
+
+				/*
+				 * If the ALTER ... RENAME statement cannot contain temp
+				 * relations, break here and let the regular code extract the
+				 * query text.
+				 */
+				if (!do_check)
+					break;
+
+				relid = rv_get_rename_relid(rename);
+
+				/*
+				 * If the relation doesn't exist and the command didn't fail
+				 * (ie. it has an IF EXIST clause), ignore the command.
+				 */
+				if (!OidIsValid(relid))
+					return NULL;
+
+				if (get_rel_persistence(relid) == RELPERSISTENCE_TEMP)
+					return NULL;
+
+				break;
+			}
+		case T_ViewStmt:
+			{
+				ViewStmt   *view = castNode(ViewStmt, stmt);
+				RawStmt    *rawstmt;
+				Query	   *viewParse;
+				RangeVar   *rv = view->view;
+
+				/* Explicit CREATE TEMP VIEW? */
+				if (rv->relpersistence == RELPERSISTENCE_TEMP)
+					return NULL;
+
+				/*
+				 * A view referring to temporary object will implicitly be a
+				 * temporary view.
+				 */
+				rawstmt = makeNode(RawStmt);
+				rawstmt->stmt = view->query;
+				rawstmt->stmt_location = query_location;
+				rawstmt->stmt_len = query_len;
+
+				viewParse = parse_analyze_fixedparams(rawstmt, query, NULL, 0,
+													  NULL);
+
+				if (isQueryUsingTempRelation(viewParse))
+					return NULL;
+
+				break;
+			}
+		default:
+			/* Nothing special to do. */
+			break;
+	}
 
 	/* First apply starting offset, unless it's -1 (unknown). */
 	if (query_location >= 0)
@@ -114,6 +397,94 @@ extract_query_text(const char *query, int query_location, int query_len)
 	extracted[query_len] = 0;
 
 	return extracted;
+}
+
+
+/* Get the Oid of a relation to be dropped.
+ *
+ * This performs the same steps as RenameRelation to identify the actual
+ * relation that is about to be modified.
+ */
+Oid
+rv_get_rename_relid(RenameStmt *stmt)
+{
+	bool		is_index_stmt = stmt->renameType == OBJECT_INDEX;
+	Oid			relid;
+
+	/*
+	 * Grab an exclusive lock on the target table, index, sequence, view,
+	 * materialized view, or foreign table, which we will NOT release until
+	 * end of transaction.
+	 *
+	 * Lock level used here should match RenameRelationInternal, to avoid lock
+	 * escalation.  However, because ALTER INDEX can be used with any relation
+	 * type, we mustn't believe without verification.
+	 */
+	for (;;)
+	{
+		LOCKMODE	lockmode;
+		char		relkind;
+		bool		obj_is_index;
+
+		lockmode = is_index_stmt ? ShareUpdateExclusiveLock : AccessExclusiveLock;
+
+		relid = RangeVarGetRelidExtended(stmt->relation, lockmode,
+										 stmt->missing_ok ? RVR_MISSING_OK : 0,
+										 RangeVarCallbackForAlterRelation,
+										 (void *) stmt);
+
+		if (!OidIsValid(relid))
+			return InvalidOid;
+
+		/*
+		 * We allow mismatched statement and object types (e.g., ALTER INDEX
+		 * to rename a table), but we might've used the wrong lock level.  If
+		 * that happens, retry with the correct lock level.  We don't bother
+		 * if we already acquired AccessExclusiveLock with an index, however.
+		 */
+		relkind = get_rel_relkind(relid);
+		obj_is_index = (relkind == RELKIND_INDEX ||
+						relkind == RELKIND_PARTITIONED_INDEX);
+		if (obj_is_index || is_index_stmt == obj_is_index)
+			break;
+
+		UnlockRelationOid(relid, lockmode);
+		is_index_stmt = obj_is_index;
+	}
+
+	return relid;
+}
+
+/* Get the Oid of a relation to be dropped.
+ *
+ * This performs the same steps as RemoveRelations to identify the actual
+ * relation that is about to be dropped.
+ */
+Oid
+rv_get_drop_relid(RangeVar *rv, char relkind, bool concurrent)
+{
+	Oid		relOid;
+	LOCKMODE	lockmode = AccessExclusiveLock;
+	struct DropRelationCallbackState state;
+
+	AcceptInvalidationMessages();
+
+	if (concurrent)
+		lockmode = ShareUpdateExclusiveLock;
+
+	/* Look up the appropriate relation using namespace search. */
+	state.expected_relkind = relkind;
+	state.heap_lockmode = concurrent ?
+		ShareUpdateExclusiveLock : AccessExclusiveLock;
+	/* We must initialize these fields to show that no locks are held: */
+	state.heapOid = InvalidOid;
+	state.partParentOid = InvalidOid;
+
+	relOid = RangeVarGetRelidExtended(rv, lockmode, RVR_MISSING_OK,
+									  RangeVarCallbackForDropRelation,
+									  (void *) &state);
+
+	return relOid;
 }
 
 /*

--- a/hack/postgres/extension/pgcapture.h
+++ b/hack/postgres/extension/pgcapture.h
@@ -7,6 +7,10 @@
 #ifndef PGCAPTURE_H
 #define PGCAPTURE_H
 
+#if PG_VERSION_NUM < 150000
+#define parse_analyze_fixedparams(a,b,c,d,e) parse_analyze(a,b,c,d,e)
+#endif
+
 /* ProcessUtility_hook */
 #if PG_VERSION_NUM >= 140000
 #define UTILITY_HOOK_ARGS PlannedStmt *pstmt, const char *queryString, \

--- a/hack/postgres/extension/sql/04_temp.sql
+++ b/hack/postgres/extension/sql/04_temp.sql
@@ -1,0 +1,48 @@
+LOAD 'pgcapture';
+
+-- Create a normal table that will later be dropped
+CREATE TABLE dropme();
+CREATE TABLE dropmetoo();
+
+TRUNCATE pgcapture.ddl_logs;
+
+-- Plain TEMP table should be ignored
+CREATE TEMPORARY TABLE tmp1();
+ALTER TABLE tmp1 ADD COLUMN id integer;
+
+-- Table created in the pg_temp schema should be ignored
+CREATE TABLE pg_temp.tmp2();
+ALTER TABLE pg_temp.tmp2 ADD COLUMN id integer;
+
+-- Table created in the pg_temp schema using the search_path should alse be
+-- ignored
+SET search_path TO not_a_schema, pg_temp, public;
+CREATE TABLE tmp3();
+ALTER TABLE tmp3 ADD COLUMN id integer;
+RESET search_path;
+
+-- CTAS / SELECT INTO for temp tables should be ignored
+CREATE TABLE pg_temp.tmp4 AS SELECT 1 AS id;
+
+-- CREATE TEMP VIEW should be ignored
+CREATE TEMP VIEW v1 AS SELECT 1 AS id;
+
+-- Implicitly temp view creation should be ignored
+CREATE VIEW v2 AS SELECT * FROM tmp3;
+
+-- ALTER ... RENAME should ignore temp relations
+ALTER TABLE tmp4 RENAME COLUMN id TO id2;
+ALTER TABLE tmp4 RENAME TO tmp4b;
+
+-- Check the results
+SELECT query, unnest(tags) FROM pgcapture.ddl_logs ORDER BY id;
+
+-- Dropping only temp tables should be ignored
+DROP TABLE tmp1, tmp2;
+
+-- But dropping a mix of temp and regular table should preserve the regular
+-- table names
+DROP TABLE tmp3, pg_temp.tmp3, dropme, tmp4b, dropmetoo CASCADE;
+
+-- Check the results
+SELECT query, unnest(tags) FROM pgcapture.ddl_logs ORDER BY id;


### PR DESCRIPTION
Fixes #71

Temporary relations are not replicated, so we shouldn't report a query string for those.

This commit adds infrastructure to detect whether a given command is for a temporary relation or not, using the same internal function as upstream postgres, to guarantee that the detection will be identical.  The detection is not always easy as unqualified relation name depends on the search_path and various rules to detect what the final relation will be.  For instance, persistent view creation are automatically switched to temporary views if they reference temporary objects.

Finally, DROP commands are even trickier as they can reference both persistent and temporary relation.  It means that a new query has to be generated to ignore any temporary relation if any.

Some other DDL may need to be similarly ignored, like GRANT / REVOKE or COMMENT ON, but it seems very unlikely to use such commands on temporary tables.  So they are not handled by this commit, to avoid too much code to maintain. Additional checks can be added later on if needed.